### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "express-slow-down": "^2.1.0",
         "helmet": "^8.1.0",
         "ioredis": "^5.6.1",
-        "rate-limit-redis": "^2.1.0"
+        "rate-limit-redis": "^2.1.0",
+        "express-rate-limit": "^8.0.1"
     },
     "devDependencies": {
         "@types/amqplib": "^0.10.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -696,8 +696,20 @@ app.patch(
 );
 
 // DELETEs use the same ratelimit bucket as the regular message endpoint, so we don't do any special ratelimit handling here.
+const rateLimit = require('express-rate-limit');
+
+const deleteRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    message: {
+        proxy: true,
+        error: 'Too many requests, please try again later.'
+    }
+});
+
 app.delete(
     '/api/webhooks/:id/:token/messages/:messageId',
+    deleteRateLimiter,
     webhookPostRatelimit,
     webhookInvalidPostRatelimit,
     async (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -700,7 +700,7 @@ const rateLimit = require('express-rate-limit');
 
 const deleteRateLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // limit each IP to 100 requests per windowMs
+    max: 1000, // limit each IP to 1000 requests per windowMs
     message: {
         proxy: true,
         error: 'Too many requests, please try again later.'


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/discord_webhook_proxy/security/code-scanning/5](https://github.com/slord399/discord_webhook_proxy/security/code-scanning/5)

To address the issue, we will apply rate-limiting middleware to the affected route handler. The `express-rate-limit` package is a well-known solution for implementing rate-limiting in Express applications. It allows us to define a maximum number of requests per time window for specific routes.

Steps to fix:
1. Install the `express-rate-limit` package if not already installed.
2. Import the package into the file.
3. Define a rate-limiting middleware with appropriate settings (e.g., maximum requests per minute).
4. Apply the middleware to the route handler on line 703 (`app.delete('/api/webhooks/:id/:token/messages/:messageId', ...)`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
