### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,7 +401,16 @@ app.get('/stats', statsEndpointRatelimit, async (req, res) => {
     });
 });
 
-app.get('/announcement', async (req, res) => {
+const announcementEndpointRatelimit = slowDown({
+    windowMs: 10000, // 10 seconds
+    delayAfter: 5, // allow 5 requests per windowMs before slowing down
+    delayMs: 500, // add 500ms delay per request above the limit
+    maxDelayMs: 30000, // cap the maximum delay at 30 seconds
+
+    store: new RedisStore({ client: redis, prefix: 'ratelimit:announcementEndpoint:' })
+});
+
+app.get('/announcement', announcementEndpointRatelimit, async (req, res) => {
     const announcement = await redis.hgetall('announcement');
 
     if (!announcement.style) {


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/discord_webhook_proxy/security/code-scanning/2](https://github.com/slord399/discord_webhook_proxy/security/code-scanning/2)

To fix the issue, we will add rate-limiting middleware to the `/announcement` endpoint. Since the project already uses the `express-slow-down` package for rate-limiting other endpoints, we will define a new rate-limiting configuration specifically for the `/announcement` route. This configuration will limit the number of requests a client can make to the endpoint within a specified time window. The rate-limiting middleware will be applied to the `/announcement` route before the route handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
