### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -617,6 +617,7 @@ app.post('/api/webhooks/:id/:token', webhookPostRatelimit, webhookInvalidPostRat
 // PATCHes use the same ratelimit bucket as the regular message endpoint, so we don't do any special ratelimit handling here.
 app.patch(
     '/api/webhooks/:id/:token/messages/:messageId',
+    patchRateLimiter,
     webhookPostRatelimit,
     webhookInvalidPostRatelimit,
     async (req, res) => {
@@ -701,6 +702,15 @@ const rateLimit = require('express-rate-limit');
 const deleteRateLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 1000, // limit each IP to 1000 requests per windowMs
+    message: {
+        proxy: true,
+        error: 'Too many requests, please try again later.'
+    }
+});
+
+const patchRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
     message: {
         proxy: true,
         error: 'Too many requests, please try again later.'

--- a/src/index.ts
+++ b/src/index.ts
@@ -710,7 +710,7 @@ const deleteRateLimiter = rateLimit({
 
 const patchRateLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // limit each IP to 100 requests per windowMs
+    max: 1000, // limit each IP to 100 requests per windowMs
     message: {
         proxy: true,
         error: 'Too many requests, please try again later.'


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/discord_webhook_proxy/security/code-scanning/4](https://github.com/slord399/discord_webhook_proxy/security/code-scanning/4)

To fix the issue, we need to apply rate-limiting middleware to the route handler flagged by CodeQL. The `express-rate-limit` package can be used to define a rate limiter that restricts the number of requests allowed within a specific time window. This middleware should be applied to the `/api/webhooks/:id/:token/messages/:messageId` route handler.

**Steps to implement the fix:**
1. Import the `express-rate-limit` package if not already imported.
2. Define a rate limiter configuration for the route handler. For example, limit each IP to 100 requests per 15 minutes.
3. Apply the rate limiter middleware to the route handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
