### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,7 +401,16 @@ app.get('/stats', statsEndpointRatelimit, async (req, res) => {
     });
 });
 
-app.get('/announcement', async (req, res) => {
+const announcementEndpointRatelimit = slowDown({
+    windowMs: 10000, // 10 seconds
+    delayAfter: 5, // allow 5 requests before slowing down
+    delayMs: 500, // add 500ms delay per request above the limit
+    maxDelayMs: 30000, // cap the delay at 30 seconds
+
+    store: new RedisStore({ client: redis, prefix: 'ratelimit:announcementEndpoint:' })
+});
+
+app.get('/announcement', announcementEndpointRatelimit, async (req, res) => {
     const announcement = await redis.hgetall('announcement');
 
     if (!announcement.style) {


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/discord_webhook_proxy/security/code-scanning/2](https://github.com/slord399/discord_webhook_proxy/security/code-scanning/2)

To fix the issue, we will add a rate-limiting mechanism to the `/announcement` endpoint. This can be achieved by using the `express-slow-down` middleware, which is already used in the codebase. We will define a new rate limiter specifically for the `/announcement` endpoint, similar to the existing `statsEndpointRatelimit`. The rate limiter will use the `RedisStore` to ensure distributed rate limiting across multiple instances of the application.

Steps:
1. Define a new rate limiter for the `/announcement` endpoint using `slowDown`.
2. Apply the rate limiter as middleware to the `/announcement` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
