### PR TITLE
Upgrade hono to fix JSX SSR HTML injection vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
         "@types/express": "^4.17.21",
         "qs": "6.15.0",
         "lodash": "4.18.1",
-        "hono": "4.12.12",
-        "@hono/node-server": "1.19.13",
+        "hono": "4.12.14",
+        "@hono/node-server": "1.19.14",
         "effect": "3.20.0",
         "path-to-regexp": "0.1.13"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,10 +38,10 @@
   resolved "https://registry.yarnpkg.com/@electric-sql/pglite/-/pglite-0.4.1.tgz#a113476c3c20539756a8d77eb86d248d84a8d097"
   integrity sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==
 
-"@hono/node-server@1.19.11", "@hono/node-server@1.19.13":
-  version "1.19.13"
-  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.13.tgz#4838c766a1237253d4dde3281cf7d5c65186fd32"
-  integrity sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==
+"@hono/node-server@1.19.11", "@hono/node-server@1.19.14":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
 
 "@ioredis/commands@1.5.1":
   version "1.5.1"
@@ -1023,10 +1023,10 @@ helmet@^8.1.0:
   resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.1.0.tgz#f96d23fedc89e9476ecb5198181009c804b8b38c"
   integrity sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==
 
-hono@4.12.12, hono@^4.12.8:
-  version "4.12.12"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.12.tgz#1f14b0ffb47c386ff50d457d66e706d9c9a7f09c"
-  integrity sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==
+hono@4.12.14, hono@^4.12.8:
+  version "4.12.14"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
+  integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
 
 http-errors@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Upgraded `hono` to version `4.12.14` and `@hono/node-server` to `1.19.14` in `package.json` resolutions to fix a security vulnerability where improperly handled JSX attribute names could allow HTML injection in `hono/jsx` SSR. Verified the update in `yarn.lock` and confirmed that the project builds successfully.

---
*PR created automatically by Jules for task [589622115775424573](https://jules.google.com/task/589622115775424573) started by @slord399*