### PR TITLE
Fix hono/jsx security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
         "@types/express": "^4.17.21",
         "qs": "6.15.0",
         "lodash": "4.18.1",
-        "hono": "4.12.14",
+        "hono": "4.12.18",
         "@hono/node-server": "1.19.14",
         "effect": "3.20.0",
         "path-to-regexp": "0.1.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,10 +999,10 @@ helmet@^8.1.0:
   resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.1.0.tgz#f96d23fedc89e9476ecb5198181009c804b8b38c"
   integrity sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==
 
-hono@4.12.14, hono@^4.12.8:
-  version "4.12.14"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
-  integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
+hono@4.12.18, hono@^4.12.8:
+  version "4.12.18"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.18.tgz#f6d301938868c3a8bdb639495f4e326a19181505"
+  integrity sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==
 
 http-errors@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Update hono to 4.12.18 in package.json resolutions to fix the "Unvalidated JSX Tag Names that May Allow HTML Injection" security vulnerability. Verified by running yarn install and yarn build.

---
*PR created automatically by Jules for task [17769035424652753076](https://jules.google.com/task/17769035424652753076) started by @slord399*