### PR TITLE
Upgrade qs to 6.15.2 to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "resolutions": {
         "@types/express": "^4.17.21",
-        "qs": "6.15.0",
+        "qs": "6.15.2",
         "lodash": "4.18.1",
         "hono": "4.12.18",
         "@hono/node-server": "1.19.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,10 +1340,10 @@ pure-rand@^6.1.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-qs@6.13.0, qs@6.15.0, qs@^6.14.1:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
-  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
+qs@6.13.0, qs@6.15.2, qs@^6.14.1:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
Upgraded `qs` from 6.15.0 to 6.15.2 in `package.json` resolutions to fix a remotely triggerable DoS vulnerability (CVE-2026-8723). Verified the fix with a reproduction script and ensured the project still builds correctly.

---
*PR created automatically by Jules for task [5927489647797379309](https://jules.google.com/task/5927489647797379309) started by @slord399*