### PR TITLE
Update Hono to 4.12.23 to patch security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
         "@types/express": "^4.17.21",
         "qs": "6.15.2",
         "lodash": "4.18.1",
-        "hono": "4.12.18",
+        "hono": "4.12.23",
         "@hono/node-server": "1.19.14",
         "effect": "3.20.0",
         "path-to-regexp": "0.1.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,10 +1000,10 @@ helmet@^8.2.0:
   resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.2.0.tgz#61cb43244de24255a288c2fddb36086074eb1812"
   integrity sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==
 
-hono@4.12.18, hono@^4.12.8:
-  version "4.12.18"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.18.tgz#f6d301938868c3a8bdb639495f4e326a19181505"
-  integrity sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==
+hono@4.12.23, hono@^4.12.8:
+  version "4.12.23"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.23.tgz#998b91651686149f0e6edbb8564d604da04f3cf8"
+  integrity sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==
 
 http-errors@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I have updated the `hono` dependency in `package.json` to version `4.12.23` and updated `yarn.lock` accordingly. This update patches four specific security vulnerabilities and functional bugs as requested.

The vulnerabilities addressed are:
- **CVE-2026-47674**: IP Restriction bypasses static deny rules for non-canonical IPv6.
- **CVE-2026-47676**: `app.mount()` strips mount prefix using undecoded path, causing incorrect routing for percent-encoded paths.
- **CVE-2026-47675**: Cookie helper does not sanitize `sameSite` and `priority`, allowing `Set-Cookie` injection.
- **CVE-2026-47673**: JWT middleware accepts any Authorization scheme, not only Bearer.

I have verified the fix by running `yarn install` and ensuring the project still builds correctly with `yarn build`.

---
*PR created automatically by Jules for task [17088036824026122305](https://jules.google.com/task/17088036824026122305) started by @slord399*