### PR TITLE
fix: resolve Prisma 7 initialization and rate limiter warnings

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -4,7 +4,7 @@
     "autoBlock": false,
     "queue": {
         "enabled": false,
-        "rabbitmq": "amqp://guest:guest@localhost",
+        "rabbitmq": "amqp://guest:guest@127.0.0.1",
         "queue": "webhook-proxy"
     },
     "redis": "redis://127.0.0.1/0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,11 +332,14 @@ app.use(bodyParser.json());
 const webhookPostRatelimit = slowDown({
     windowMs: 2000,
     delayAfter: 5,
-    delayMs: 1000,
+    delayMs: (used: number, req: any) => (used - req.slowDown.limit) * 1000,
     maxDelayMs: 30000,
 
-        keyGenerator(req: any, res: any) {
-        return req.params.id ?? req.ip; // use the webhook ID as a ratelimiting key, otherwise use IP
+    keyGenerator(req: any, res: any) {
+        return (req.params.id ?? req.ip ?? '').toString(); // use the webhook ID as a ratelimiting key, otherwise use IP
+    },
+    validate: {
+        keyGeneratorIpFallback: false
     },
 
     // @ts-ignore - The types for rate-limit-redis are not compatible with ioredis, so we have to cast to any
@@ -346,11 +349,14 @@ const webhookPostRatelimit = slowDown({
 const webhookQueuePostRatelimit = slowDown({
     windowMs: 1000,
     delayAfter: 10,
-    delayMs: 1000,
+    delayMs: (used: number, req: any) => (used - req.slowDown.limit) * 1000,
     maxDelayMs: 30000,
 
-        keyGenerator(req: any, res: any) {
-        return req.params.id ?? req.ip; // use the webhook ID as a ratelimiting key, otherwise use IP
+    keyGenerator(req: any, res: any) {
+        return (req.params.id ?? req.ip ?? '').toString(); // use the webhook ID as a ratelimiting key, otherwise use IP
+    },
+    validate: {
+        keyGeneratorIpFallback: false
     },
 
     // @ts-ignore - The types for rate-limit-redis are not compatible with ioredis, so we have to cast to any
@@ -360,14 +366,17 @@ const webhookQueuePostRatelimit = slowDown({
 const webhookInvalidPostRatelimit = slowDown({
     windowMs: 30000,
     delayAfter: 3,
-    delayMs: 1000,
+    delayMs: (used: number, req: any) => (used - req.slowDown.limit) * 1000,
     maxDelayMs: 30000,
 
-        keyGenerator(req: any, res: any) {
-        return req.params.id ?? req.ip; // use the webhook ID as a ratelimiting key, otherwise use IP
+    keyGenerator(req: any, res: any) {
+        return (req.params.id ?? req.ip ?? '').toString(); // use the webhook ID as a ratelimiting key, otherwise use IP
+    },
+    validate: {
+        keyGeneratorIpFallback: false
     },
 
-        skip(req: any, res: any) {
+    skip(req: any, res: any) {
         return !(res.statusCode >= 400 && res.statusCode < 500 && res.statusCode !== 429); // trigger if it's a 4xx but not a ratelimit
     },
 
@@ -378,7 +387,7 @@ const webhookInvalidPostRatelimit = slowDown({
 const unknownEndpointRatelimit = slowDown({
     windowMs: 10000,
     delayAfter: 10,
-    delayMs: 500,
+    delayMs: (used: number, req: any) => (used - req.slowDown.limit) * 500,
     maxDelayMs: 30000,
 
     // @ts-ignore - The types for rate-limit-redis are not compatible with ioredis, so we have to cast to any
@@ -388,7 +397,7 @@ const unknownEndpointRatelimit = slowDown({
 const statsEndpointRatelimit = slowDown({
     windowMs: 5000,
     delayAfter: 1,
-    delayMs: 500,
+    delayMs: (used: number, req: any) => (used - req.slowDown.limit) * 500,
     maxDelayMs: 30000,
 
     // @ts-ignore - The types for rate-limit-redis are not compatible with ioredis, so we have to cast to any

--- a/src/queueProcessor.ts
+++ b/src/queueProcessor.ts
@@ -27,6 +27,11 @@ const client = axios.create({
 let rabbitMq: amqp.Channel;
 
 async function run() {
+    if (!config.queue.enabled) {
+        log('Queue processing is disabled in config. Exiting.');
+        process.exit(0);
+    }
+
     try {
         rabbitMq = await setup(config.queue.rabbitmq, config.queue.queue);
 


### PR DESCRIPTION
- Implemented Driver Adapter for SQLite using `better-sqlite3` to fix `PrismaClientInitializationError` in Prisma 7.
- Updated `rate-limit-redis` initialization to use `sendCommand` for v5 compatibility.
- Updated `express-slow-down` calls to use function-based `delayMs` for v2 compatibility.
- Suppressed `express-rate-limit` IPv6 validation warnings by explicitly setting `keyGeneratorIpFallback: false`.
- Improved RabbitMQ configuration example and queue processor reliability.