### PR TITLE
Resolve TSConfig compilation errors and clean up deprecations

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,7 @@
         "@types/amqplib": "^0.10.8",
         "@types/better-sqlite3": "^7.6.13",
         "@types/express": "^4.17.21",
-        "@types/express-rate-limit": "^6.0.2",
-        "@types/express-slow-down": "^2.0.0",
-        "@types/ioredis": "^5.0.0",
         "@types/node": "^26.1.1",
-        "@types/rate-limit-redis": "^3.0.0",
         "prisma": "7.8.0",
         "rimraf": "^6.1.3",
         "typescript": "^7.0.2"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,6 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["driverAdapters"]
 }
 
 model BannedWebhook {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,18 +4,11 @@
         "esModuleInterop": true,
         "target": "ESNext",
         "noImplicitAny": true,
-        "moduleResolution": "node",
         "ignoreDeprecations": "6.0",
         "strict": false,
         "rootDir": "./src",
         "sourceMap": true,
-        "outDir": "./dist",
-        "baseUrl": ".",
-        "paths": {
-            "*": [
-                "./node_modules/*"
-            ]
-        }
+        "outDir": "./dist"
     },
     "include": [
         "./src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,13 +355,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-rate-limit@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/express-rate-limit/-/express-rate-limit-6.0.2.tgz#88c2d577cf8463568986e888b9697d82d6a69a88"
-  integrity sha512-e1xZLOOlxCDvplAGq7rDcXtbdBu2CWRsMjaIu1LVqGxWtKvwr884YE5mPs3IvHeG/OMDhf24oTaqG5T1bV3rBQ==
-  dependencies:
-    express-rate-limit "*"
-
 "@types/express-serve-static-core@^4.17.33":
   version "4.19.6"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz#e01324c2a024ff367d92c66f48553ced0ab50267"
@@ -371,13 +364,6 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
     "@types/send" "*"
-
-"@types/express-slow-down@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/express-slow-down/-/express-slow-down-2.0.0.tgz#faa781d1b57c236f0357e6a37e320c751153da9f"
-  integrity sha512-pTkMCl0B1ypB26An5F0DVxC/Emi0yiapThxUDsL/mRQ+Szmoeuximv4XqgZm8lY5ZHqH/DQ8FschjxWWMUpQlQ==
-  dependencies:
-    express-slow-down "*"
 
 "@types/express@^4.17.21":
   version "4.17.23"
@@ -393,13 +379,6 @@
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
   integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
-
-"@types/ioredis@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-5.0.0.tgz#c1ea7e2f3e2c5a942a27cfee6f62ddcfb23fb3e7"
-  integrity sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==
-  dependencies:
-    ioredis "*"
 
 "@types/mime@^1":
   version "1.3.5"
@@ -422,13 +401,6 @@
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
-
-"@types/rate-limit-redis@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/rate-limit-redis/-/rate-limit-redis-3.0.0.tgz#5dc84d2ce6924da3360ec300502080e6d5301d61"
-  integrity sha512-BW3tros2nmZOJLkoQPBViUhzOWBOwFnIWUevG5+NpFVmngb8RulB4p/nkEhYyOrrKR5UJ74GCT7nyDG6zr+isQ==
-  dependencies:
-    rate-limit-redis "*"
 
 "@types/send@*":
   version "0.17.5"
@@ -974,14 +946,14 @@ express-async-errors@^3.1.1:
   resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
   integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
 
-express-rate-limit@*, express-rate-limit@8, express-rate-limit@^8.5.2:
+express-rate-limit@8, express-rate-limit@^8.5.2:
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz#5922dbf76df2124611cea955d93432b37514b2f3"
   integrity sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==
   dependencies:
     ip-address "^10.2.0"
 
-express-slow-down@*, express-slow-down@^3.1.0:
+express-slow-down@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/express-slow-down/-/express-slow-down-3.1.0.tgz#13868d00825f4df670a5c1136c35491962fa0761"
   integrity sha512-0gZ1HHow8H83z1/+81DdWB60RSGHI0mJB0ZM1m5P6/BexORFcA8P1TgU0NKEwOiRmxyCIoktZYqmA+1UCc83+A==
@@ -1289,7 +1261,7 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-ioredis@*, ioredis@^5.11.1:
+ioredis@^5.11.1:
   version "5.11.1"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.11.1.tgz#2d1e52e350a79ee3b00883f3681a410427b49f28"
   integrity sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==
@@ -1642,7 +1614,7 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-rate-limit-redis@*, rate-limit-redis@^5.0.0:
+rate-limit-redis@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/rate-limit-redis/-/rate-limit-redis-5.0.0.tgz#bac2fdf139d9aba8f33c00310bfdacbd6582786f"
   integrity sha512-+M9el8KZjZ2HXM6/E38jFGmozBbN4C200iLE8+80TgS+8PzSfAAvD1zkx2oWu6YEgSrdiJJNrd4LCFm5vjVJkg==


### PR DESCRIPTION
This PR addresses all compilation errors and deprecation warnings in the project configuration. First, it corrects the tsconfig.json issues by removing 'moduleResolution' (which was mapping to node10) and the deprecated 'baseUrl' / 'paths' properties. Second, it removes the deprecated 'driverAdapters' preview feature in the Prisma schema since it is now standard in Prisma 7+. Finally, it cleans up package.json by removing stub types for rate-limit-redis, ioredis, express-slow-down, and express-rate-limit, which now bundle their own type definitions natively. All changes were built and verified successfully.

---
*PR created automatically by Jules for task [16183080150050732548](https://jules.google.com/task/16183080150050732548) started by @slord399*