### PR TITLE
feat: modernize package manager to Yarn Berry, fix Prisma 7 client ge…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "preinstall": "node preinstall.js yarn",
         "update": "git pull && NODE_OPTIONS=--no-deprecation yarn && NODE_OPTIONS=--no-deprecation yarn build && pm2 reload webhook-proxy webhook-proxy-processor || true",
-        "build": "NODE_OPTIONS=--no-deprecation prisma migrate deploy && NODE_OPTIONS=--no-deprecation prisma generate && rimraf dist && tsc",
+        "build": "NODE_OPTIONS=--no-deprecation yarn prisma migrate deploy && NODE_OPTIONS=--no-deprecation yarn prisma generate && rimraf dist && tsc",
         "start": "yarn build && NODE_OPTIONS=--no-deprecation node dist"
     },
     "dependencies": {


### PR DESCRIPTION
…neration and resolve warnings

- Upgraded the package manager to stable Yarn Berry (v4.17.1) with 'nodeLinker: node-modules' layout.
- Added logFilters to '.yarnrc.yml' to silence peer and rebuild warnings.
- Enforced Yarn using our custom zero-dependency preinstall.js script which automatically finds and deletes package-lock.json and other incompatible lockfiles.
- Resolved brace-expansion security vulnerability via resolutions to '^2.0.1'.
- Added @prisma/client explicitly under dependencies in package.json.
- Simplified prisma.config.ts by exporting a plain config object to bypass module resolution issues.
- Configured Prisma generator in prisma/schema.prisma to output locally to ../src/generated/prisma, and updated imports in src/index.ts to use ./generated/prisma.
- Updated build scripts in package.json to run prisma commands via 'yarn prisma' to resolve module paths correctly under Yarn Berry, and prepended NODE_OPTIONS=--no-deprecation to silence url.parse() deprecation warnings from third-party tools during execution.