### PR TITLE
Fix Dependabot Alert: Upgrade brace-expansion to v5.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "undici": "6.27.0",
         "effect": "3.20.0",
         "path-to-regexp": "0.1.13",
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.8"
     },
     "license": "MIT",
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,10 +766,10 @@ axios@^1.18.1:
     https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -810,12 +810,12 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-brace-expansion@^2.0.1, brace-expansion@^5.0.5:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+brace-expansion@^5.0.5, brace-expansion@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
-    balanced-match "^1.0.0"
+    balanced-match "^4.0.2"
 
 buffer@^5.5.0:
   version "5.7.1"


### PR DESCRIPTION
Resolves CVE-2026-14257 in `brace-expansion` by upgrading it from version 2.1.2 to 5.0.8. Since `package.json` resolutions previously forced `brace-expansion` to `^2.0.1`, `minimatch`'s dependency on `brace-expansion@^5.0.5` resolved to `2.1.2`, leaving the application vulnerable. Upgrading the resolution to `^5.0.8` successfully resolves this issue and cleans up the yarn lockfile.

---
*PR created automatically by Jules for task [15966305546416096137](https://jules.google.com/task/15966305546416096137) started by @slord399*