### PR TITLE
Fix Redis connection crashes and update undici dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "lodash": "4.18.1",
         "hono": "4.13.2",
         "@hono/node-server": "^2.0.5",
-        "undici": "6.27.0",
+        "undici": "^6.28.0",
         "effect": "3.20.0",
         "path-to-regexp": "0.1.13",
         "brace-expansion": "^5.0.9"

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,19 @@ const config = JSON.parse(fs.readFileSync('./config.json', 'utf8')) as {
 
 const adapter = new PrismaBetterSqlite3({ url: 'file:./proxy.db' });
 const db = new PrismaClient({ adapter });
-const redis = new Redis(config.redis);
+
+const redis = new Redis(config.redis, {
+    maxRetriesPerRequest: null,
+    retryStrategy(times: number) {
+        const delay = Math.min(times * 100, 3000);
+        warn(`[ioredis] Redis connection retry attempt ${times}, delaying ${delay}ms`);
+        return delay;
+    }
+});
 
 // Prevent the process from crashing on Redis connection errors
 redis.on('error', (err) => {
-    error('Redis error encountered:', err);
+    error('[ioredis] Redis Client Error:', err);
 });
 
 beforeShutdown(async () => {

--- a/src/queueProcessor.ts
+++ b/src/queueProcessor.ts
@@ -18,7 +18,18 @@ const config = JSON.parse(fs.readFileSync('./config.json', 'utf8')) as {
     redis: string;
 };
 
-const redis = new Redis(config.redis);
+const redis = new Redis(config.redis, {
+    maxRetriesPerRequest: null,
+    retryStrategy(times: number) {
+        const delay = Math.min(times * 100, 3000);
+        warn(`[ioredis] Redis connection retry attempt ${times}, delaying ${delay}ms`);
+        return delay;
+    }
+});
+
+redis.on('error', (err) => {
+    error('[ioredis] Redis Client Error:', err);
+});
 
 const client = axios.create({
     validateStatus: () => true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,10 +1913,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@6.27.0, undici@^6.23.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+undici@^6.23.0, undici@^6.28.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 universal-user-agent@^7.0.0, universal-user-agent@^7.0.2:
   version "7.0.3"


### PR DESCRIPTION
- Configured `ioredis` instances in `src/index.ts` and `src/queueProcessor.ts` with `retryStrategy`, `maxRetriesPerRequest: null`, and explicit `'error'` event listeners to prevent process crashes on Redis disconnection / `ECONNREFUSED`.
- Updated `undici` in `package.json` resolutions to `^6.28.0` and regenerated `yarn.lock` to patch downstream security vulnerabilities.

---
*PR created automatically by Jules for task [3510673364292766515](https://jules.google.com/task/3510673364292766515) started by @slord399*